### PR TITLE
docs: add slog usage examples and update doc.go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2025-06-10
+
+### Documentation
+
+- Added `slog` usage examples to `README.md`.
+- Expanded `doc.go` with structured logging and stack trace formatting details.
+
+
+## [1.0.0] - 2025-06-09
+
+Initial stable release with structured logging support.
+
+### Features
+
+- Implemented `slog.LogValuer` for `*Error`, enabling structured logging of error messages and stack traces.
+- Supports configurable stack trace formats:
+  - `string array` (default)
+  - `object array` (structured)
+
+
 ## [v0.1.1] - 2025-06-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ go get github.com/stackprune/errors
 ## Core API Comparison
 
 | Function      | stackprune/errors                           | pkg/errors                 |
-|---------------|---------------------------------------------|----------------------------|
+| ------------- | ------------------------------------------- | -------------------------- |
 | `New()`       | Captures stack once                         | Captures stack             |
 | `Wrap()`      | Adds message, no new stack                  | Adds message + stack       |
 | `WithStack()` | Adds stack if missing                       | Always adds stack          |
@@ -114,6 +114,65 @@ fmt.Printf("%+v\n", err) // shows full stack from the point where error was crea
 * This library requires **Go 1.22+**. Older versions are not supported or tested.
 * `Join` provides the same semantics as Go 1.20's `errors.Join`, with internal fallback for compatibility.
 * Stack traces are only captured once — even when wrapping multiple times — keeping logs concise.
+
+---
+
+## Structured Logging with `slog`
+
+This library integrates with the [`slog`](https://pkg.go.dev/log/slog) package to enable structured logging of rich error data, including stack traces.
+
+### Enabling `slog.LogValuer`
+
+The `*Error` type implements `slog.LogValuer`. When passed to a `slog.Logger`, it emits a structured object including the error message and optionally the stack trace.
+
+```go
+err := errors.WithStack(errors.New("failed to open config"))
+logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+logger.Error("operation failed", slog.Any("error", err))
+```
+
+#### Output (default format):
+
+```json
+{
+  "time": "2025-06-10T09:55:08.038826176+09:00",
+  "level": "ERROR",
+  "msg": "operation failed",
+  "error": {
+    "message": "failed to open config",
+    "kind": "*errors.Error",
+    "stack": [
+      "openConfig at project/config.go:42",
+      "main at project/main.go:10"
+    ]
+  }
+}
+```
+
+### Customizing Stack Trace Format
+
+You can control how stack traces are serialized using the `SetStackFormatter` function:
+
+```go
+errors.SetStackFormatter(errors.StackAsObjects)
+```
+
+Result:
+
+```json
+"stack": [
+  {
+    "func": "openConfig",
+    "file": "config.go",
+    "line": 42
+  },
+  {
+    "func": "main",
+    "file": "main.go",
+    "line": 10
+  }
+]
+```
 
 ---
 

--- a/doc.go
+++ b/doc.go
@@ -5,4 +5,6 @@
 //
 // The API includes `New`, `Wrap`, `Errorf`, `WithStack`, and `Join`, offering
 // familiar ergonomics without the noise of `WithMessage` or similar.
+//
+// The *Error type also implements slog.LogValuer for structured logging.
 package errors

--- a/example_test.go
+++ b/example_test.go
@@ -4,6 +4,8 @@ import (
 	stderrors "errors"
 	"fmt"
 	"io"
+	"log/slog"
+	"os"
 
 	"github.com/stackprune/errors"
 )
@@ -166,4 +168,26 @@ func ExampleWrap_networkError() {
 	fmt.Println(serviceErr.Error())
 
 	// Output: failed to fetch data from api.example.com: network connection lost: unexpected EOF
+}
+
+func Example_slogStructuredLogging() {
+	err := errors.WithStack(errors.New("missing config"))
+
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	logger.Error("initialization failed", slog.Any("error", err))
+
+	// Example output:
+	// {
+	//   "time": "2025-06-10T10:01:44.693101023+09:00",
+	//   "level": "ERROR",
+	//   "msg": "initialization failed",
+	//   "error": {
+	//     "message": "missing config",
+	//     "kind": "*errors.Error",
+	//     "stack": [
+	//       "loadConfig at config.go:42",
+	//       "main at main.go:10"
+	//     ]
+	//   }
+	// }
 }

--- a/example_test.go
+++ b/example_test.go
@@ -170,6 +170,9 @@ func ExampleWrap_networkError() {
 	// Output: failed to fetch data from api.example.com: network connection lost: unexpected EOF
 }
 
+// Example_slogStructuredLogging demonstrates how to use slog for structured logging
+//
+//nolint:testableexamples
 func Example_slogStructuredLogging() {
 	err := errors.WithStack(errors.New("missing config"))
 


### PR DESCRIPTION
- Expanded README.md with structured logging usage via slog.LogValuer
- Added JSON output examples and stack formatter notes
- Documented slog support in doc.go header
- Added Example_slogStructuredLogging in example_test.go for GoDoc