### PR TITLE
feat: add panic recovery helpers and stack trace utilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2025-06-16
+
+### Added
+- `NewWithCallers` function for creating errors with custom stack traces from program counters, particularly useful for panic/recover scenarios where you need to preserve the original stack context.
+- `RecoverError` helper function for convenient error creation from panic recovery values with proper stack trace capture.
+- `ProgramCounters()` method on `Error` type for accessing raw program counters (primarily for testing and advanced debugging).
+
+### Improved
+- Enhanced panic recovery capabilities with dedicated helper functions for common patterns.
+- Improved stack trace filtering to show only relevant frames (`runtime.goexit`, `runtime.main` instead of all `runtime.*` functions).
+- Better integration with defer/recover patterns commonly used in Go applications.
+
+### Documentation
+- Major rewrite of README.md for improved usability and clarity.
+
+
 ## [1.0.2] - 2025-06-12
 
 ### Improved
-
 - Enhanced `SetLogOptions` function to automatically apply default values for empty keys, improving usability.
 - Reorganized README.md structure for better readability:
   - Moved structured logging (`slog`) section after basic usage examples
@@ -16,16 +31,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Fixed documentation inaccuracies in slog usage examples
 
 ### Fixed
-
 - Corrected README.md documentation errors:
   - Fixed non-existent function name (`SetStackFormatter` → `SetLogOptions`)
   - Fixed non-existent constant name (`StackAsObjects` → `StackFormatObjectArray`)
   - Fixed JSON field name in examples (`"func"` → `"function"`)
 
+
 ## [1.0.1] - 2025-06-10
 
 ### Documentation
-
 - Added `slog` usage examples to `README.md`.
 - Expanded `doc.go` with structured logging and stack trace formatting details.
 
@@ -35,7 +49,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Initial stable release with structured logging support.
 
 ### Features
-
 - Implemented `slog.LogValuer` for `*Error`, enabling structured logging of error messages and stack traces.
 - Supports configurable stack trace formats:
   - `string array` (default)

--- a/README.md
+++ b/README.md
@@ -1,37 +1,21 @@
 # stackprune/errors
 
-`stackprune/errors` is a lightweight, modern error handling library for Go, designed as a clean alternative to `pkg/errors`.
+A modern, lightweight error handling library for Go — focused on:
 
-It captures **one stack trace** at the point where the error is created and preserves it through all wrapping, avoiding redundant trace output. This makes the %+v output readable and focused — exactly what you need for debugging.
-
-## Why Use stackprune/errors?
-
-- ✅ Clean, single-source stack trace (no duplication)
-- ✅ Minimalistic API inspired by `pkg/errors`
-- ✅ `%+v` formatting shows clear trace
-- ✅ Fully compatible with Go 1.13+ error wrapping (`errors.Is`, `errors.As`, `errors.Unwrap`)
-- ✅ No `WithMessage` clutter — just `Wrap()`
-- ✅ Lightweight and dependency-free
+* ✅ Clean, single-stack trace errors (no duplication)
+* ✅ Full compatibility with Go's `errors` package
+* ✅ Seamless structured logging via `slog`
+* ✅ Panic recovery helpers with preserved stack
+* ✅ No external dependencies
 
 ---
 
-## Why not `pkg/errors`?
+## Why stackprune/errors?
 
-`pkg/errors` captures a new stack trace every time you call `Wrap()`. This results in bloated, duplicated stack outputs:
+Go's standard `errors` and popular `pkg/errors` often capture new stack traces on each wrap, leading to redundant, noisy stack dumps.
 
-```go
-err := errors.New("root cause")        // <- captures stack
-err = errors.Wrap(err, "level 2")      // <- new stack
-err = errors.Wrap(err, "level 3")      // <- yet another stack
-```
-
-With `stackprune/errors`, stack is captured **only once**:
-
-```go
-err := errors.New("root cause")        // captures stack here
-err = errors.Wrap(err, "level 2")      // adds message, no new stack
-err = errors.Wrap(err, "level 3")      // same original stack
-```
+**stackprune/errors captures the stack once at the origin and preserves it across all wraps.**
+No redundant stacks. Clean, minimal, highly debuggable output.
 
 ---
 
@@ -43,92 +27,152 @@ go get github.com/stackprune/errors
 
 ---
 
-## Core API Comparison
-
-| Function      | stackprune/errors                           | pkg/errors                 |
-| ------------- | ------------------------------------------- | -------------------------- |
-| `New()`       | Captures stack once                         | Captures stack             |
-| `Wrap()`      | Adds message, no new stack                  | Adds message + stack       |
-| `WithStack()` | Adds stack if missing                       | Always adds stack          |
-| `Errorf()`    | Formats message and captures stack          | Formats and captures stack |
-| `Join()`      | Uses Go 1.20+ `errors.Join` (with fallback) | Not available              |
-
----
-
-## Usage
-
-Basic error creation and wrapping:
+## Quick Start
 
 ```go
 import "github.com/stackprune/errors"
 
-func loadConfig() error {
-    return errors.New("missing config file")
-}
+// Create error with stack trace
+err := errors.New("failed to connect")
 
-func runApp() error {
-    err := loadConfig()
-    return errors.Wrap(err, "failed to start app")
-}
+// Wrap with additional context (preserves stack)
+err = errors.Wrap(err, "while starting server")
+
+// Format errors
+err = errors.Errorf("user %d not found", userID)
+
+// Add stack to 3rd party errors
+err = errors.WithStack(io.EOF)
+
+// Print with full stack trace
+fmt.Printf("%+v\n", err)
 ```
 
-Formatted error messages:
+---
+
+## Key API Summary
+
+| Function           | Purpose                                    |
+| ------------------ | ------------------------------------------ |
+| `New()`            | Create error, capture stack once           |
+| `Wrap()`           | Add context, no new stack                  |
+| `WithStack()`      | Attach stack if missing                    |
+| `Errorf()`         | Formatted error with stack                 |
+| `Join()`           | Combine multiple errors                    |
+| `RecoverError()`   | Build error from panic recovery            |
+| `NewWithCallers()` | Build error from external program counters |
+
+Full API: [Go Reference](https://pkg.go.dev/github.com/stackprune/errors)
+
+---
+
+## Panic Recovery
+
+Capture panics with full stack trace easily:
 
 ```go
-if err := doSomething(); err != nil {
-    return errors.Errorf("operation failed: %w", err)
+func safeOperation() (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = errors.RecoverError(fmt.Sprintf("panic: %v", r))
+		}
+	}()
+	panic("something failed")
 }
 ```
 
-Adding a stack trace to third-party errors:
+For advanced control (external call stacks):
 
 ```go
-if err := thirdPartyFunc(); err != nil {
-    return errors.WithStack(err)
+func advancedRecovery() (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			var pcs [32]uintptr
+			n := runtime.Callers(0, pcs[:])
+			err = errors.NewWithCallers(fmt.Sprint(r), pcs[:n])
+		}
+	}()
+	panic("something failed")
 }
 ```
 
-Combining multiple errors:
+---
+
+## Multiple Error Handling
 
 ```go
 var errs []error
 
 if err := op1(); err != nil {
-    errs = append(errs, err)
+	errs = append(errs, errors.Wrap(err, "op1 failed"))
 }
 if err := op2(); err != nil {
-    errs = append(errs, err)
+	errs = append(errs, errors.Wrap(err, "op2 failed"))
 }
 
 return errors.Join(errs...)
 ```
 
-Pretty-printing with stack trace:
-
-```go
-fmt.Printf("%+v\n", err) // shows full stack from the point where error was created
-```
-
-### Notes
-
-* This library requires **Go 1.22+**. Older versions are not supported or tested.
-* `Join` provides the same semantics as Go 1.20's `errors.Join`, with internal fallback for compatibility.
-* Stack traces are only captured once — even when wrapping multiple times — keeping logs concise.
-
 ---
 
-## Example Output
+## Structured Logging (slog)
+
+Seamless integration with Go's `slog`:
 
 ```go
-if err := handler_createUser(); err != nil {
-    fmt.Printf("%+v\n", err)
+err := errors.New("database failure")
+logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+logger.Error("operation failed", slog.Any("error", err))
+```
+
+**Output example:**
+
+```json
+{
+  "level": "ERROR",
+  "msg": "operation failed",
+  "error": {
+    "message": "database failure",
+    "kind": "*errors.Error",
+    "stack": [
+      "connectDB at db.go:42",
+      "main at main.go:10"
+    ]
+  }
 }
 ```
 
-Output:
+### Customizing stack output
+
+```go
+errors.SetLogOptions(errors.LogOptions{
+	StackFormat: errors.StackFormatObjectArray,
+})
+```
+
+Produces:
+
+```json
+"stack": [
+  {"file": "db.go", "function": "connectDB", "line": 42},
+  {"file": "main.go", "function": "main", "line": 10}
+]
+```
+
+---
+
+## Debug Output
+
+Use `%+v` to print full error with stack trace:
+
+```go
+fmt.Printf("%+v\n", err)
+```
+
+Example output:
 
 ```
-user creation failed: failed to insert user into database
+user creation failed: failed to insert
 main.repositoryInsertUser
     /app/main.go:133
 main.usecaseCreateUser
@@ -139,76 +183,14 @@ main.main
     /app/main.go:139
 ```
 
-✔ Stack trace shown once  
-✔ No duplication  
-✔ Easy to follow
-
 ---
 
-## Structured Logging with `slog`
+## Requirements
 
-This library integrates with the [`slog`](https://pkg.go.dev/log/slog) package to enable structured logging of rich error data, including stack traces.
-
-### Basic `slog` Integration
-
-The `*Error` type implements `slog.LogValuer`. When passed to a `slog.Logger`, it emits a structured object including the error message and optionally the stack trace.
-
-```go
-err := errors.WithStack(errors.New("failed to open config"))
-logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
-logger.Error("operation failed", slog.Any("error", err))
+```txt
+Go 1.22+
+Zero external dependencies
 ```
-
-#### Output (default format):
-
-```json
-{
-  "time": "2025-06-10T09:55:08.038826176+09:00",
-  "level": "ERROR",
-  "msg": "operation failed",
-  "error": {
-    "message": "failed to open config",
-    "kind": "*errors.Error",
-    "stack": [
-      "openConfig at project/config.go:42",
-      "main at project/main.go:10"
-    ]
-  }
-}
-```
-
-### Customizing Stack Trace Format
-
-You can control how stack traces are serialized using the `SetLogOptions` function:
-
-```go
-errors.SetLogOptions(errors.LogOptions{
-    StackFormat: errors.StackFormatObjectArray,
-})
-```
-
-Result:
-
-```json
-"stack": [
-  {
-    "file": "config.go",
-    "function": "openConfig",
-    "line": 42
-  },
-  {
-    "file": "main.go",
-    "function": "main",
-    "line": 10
-  }
-]
-```
-
----
-
-## API Reference
-
-See [Go Reference](https://pkg.go.dev/github.com/stackprune/errors) for full API documentation.
 
 ---
 

--- a/compat_pkg.go
+++ b/compat_pkg.go
@@ -40,7 +40,7 @@ func wrapWithMessage(err error, message string) error {
 		programCounters = errorWithStack.programCounters
 		cachedStacks = errorWithStack.cachedStacks
 	} else {
-		programCounters = callers()
+		programCounters = callers(0)
 	}
 
 	return &Error{

--- a/compat_pkg_test.go
+++ b/compat_pkg_test.go
@@ -103,9 +103,9 @@ func TestWrap(t *testing.T) {
 			require.Equal(t, tt.want, got.Error())
 
 			// Check that stack trace is preserved/added
-			stackErr := &errors.Error{}
-			ok := stderrors.As(got, &stackErr)
-			assert.True(t, ok)
+			var stackErr *errors.Error
+
+			require.ErrorAs(t, got, &stackErr)
 			assert.NotEmpty(t, stackErr.Stacks())
 		})
 	}
@@ -174,9 +174,9 @@ func TestWrapf(t *testing.T) {
 			require.Equal(t, tt.want, got.Error())
 
 			// Check that stack trace is preserved/added
-			stackErr := &errors.Error{}
-			ok := stderrors.As(got, &stackErr)
-			require.True(t, ok)
+			var stackErr *errors.Error
+
+			require.ErrorAs(t, got, &stackErr)
 			assert.NotEmpty(t, stackErr.Stacks())
 		})
 	}

--- a/core.go
+++ b/core.go
@@ -15,7 +15,18 @@ func New(message string) error {
 	return &Error{
 		err:             nil,
 		message:         message,
-		programCounters: callers(),
+		programCounters: callers(0),
+		cachedStacks:    nil,
+	}
+}
+
+// NewWithCallers creates an error with a message and provided program counters.
+// It allows attaching an external stack trace, e.g., from recover handlers.
+func NewWithCallers(message string, programCounters []uintptr) error {
+	return &Error{
+		err:             nil,
+		message:         message,
+		programCounters: programCounters,
 		cachedStacks:    nil,
 	}
 }
@@ -30,7 +41,7 @@ func Errorf(format string, args ...any) error {
 	return &Error{
 		err:             nil,
 		message:         fmt.Sprintf(format, args...),
-		programCounters: callers(),
+		programCounters: callers(0),
 		cachedStacks:    nil,
 	}
 }
@@ -38,6 +49,15 @@ func Errorf(format string, args ...any) error {
 // Is reports whether err is or wraps target, same as errors.Is.
 func Is(err, target error) bool {
 	return errors.Is(err, target)
+}
+
+// RecoverError creates an error with a message and stack trace.
+// This is a convenience function for defer/recover patterns where you want
+// to capture the current stack trace.
+func RecoverError(message string) error {
+	programCounters := callers(1)
+
+	return NewWithCallers(message, programCounters)
 }
 
 // Unwrap returns the result of calling the Unwrap method on err, if any.

--- a/core_test.go
+++ b/core_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stackprune/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNew(t *testing.T) {
@@ -42,6 +43,20 @@ func TestNew(t *testing.T) {
 			assert.Equal(t, tt.want.Error(), got)
 		})
 	}
+}
+
+func TestNewWithCallers(t *testing.T) {
+	t.Parallel()
+
+	var customErr *errors.Error
+
+	pcs := []uintptr{0x1234, 0x5678, 0x9abc}
+	err := errors.NewWithCallers("foo", pcs)
+
+	require.ErrorAs(t, err, &customErr)
+	programCounters := customErr.ProgramCounters()
+
+	assert.Equal(t, pcs, programCounters)
 }
 
 func TestAs(t *testing.T) {
@@ -197,6 +212,29 @@ func TestIs(t *testing.T) {
 			assert.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestRecoverError(t *testing.T) {
+	t.Parallel()
+
+	// Test typical recovery scenario
+	recoverFunc := func() (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = errors.RecoverError(fmt.Sprintf("panic recovered: %v", r))
+			}
+		}()
+
+		panic("something went wrong")
+	}
+
+	err := recoverFunc()
+	assert.Equal(t, "panic recovered: something went wrong", err.Error())
+
+	var stackErr *errors.Error
+
+	require.ErrorAs(t, err, &stackErr)
+	assert.NotEmpty(t, stackErr.Stacks())
 }
 
 func TestUnwrap(t *testing.T) {

--- a/error.go
+++ b/error.go
@@ -7,6 +7,7 @@ package errors
 import (
 	"fmt"
 	"io"
+	"slices"
 	"strings"
 )
 
@@ -68,6 +69,11 @@ func (e *Error) Format(state fmt.State, verb rune) {
 	}
 }
 
+// ProgramCounters returns the raw program counters (for testing).
+func (e *Error) ProgramCounters() []uintptr {
+	return e.programCounters
+}
+
 // Stacks returns the stack trace.
 func (e *Error) Stacks() []Stack {
 	if e.cachedStacks != nil {
@@ -83,7 +89,10 @@ func (e *Error) Stacks() []Stack {
 			continue
 		}
 
-		if strings.HasPrefix(stack.FuncName, "runtime.") || stack.FuncName == "testing.runExample" {
+		if slices.Contains(
+			[]string{"runtime.goexit", "runtime.main", "testing.runExample"},
+			stack.FuncName,
+		) {
 			break
 		}
 

--- a/example_test.go
+++ b/example_test.go
@@ -194,3 +194,31 @@ func Example_slogStructuredLogging() {
 	//   }
 	// }
 }
+
+// ExampleRecoverError demonstrates error creation from panic recovery.
+//
+//nolint:testableexamples
+func ExampleRecoverError() {
+	safeFunc := func() (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = errors.RecoverError(fmt.Sprintf("database operation failed: %v", r))
+			}
+		}()
+
+		// This will panic
+		panic("connection timeout")
+	}
+
+	err := safeFunc()
+	fmt.Printf("%+v\n", err)
+
+	// Example Output:
+	// database operation failed: connection timeout
+	// runtime.gopanic
+	// 	/usr/local/go/src/runtime/panic.go:770
+	// github.com/stackprune/errors_test.ExampleRecoverError.func1
+	// 	/app/example_test.go:208
+	// github.com/stackprune/errors_test.ExampleRecoverError
+	// 	/app/example_test.go:211
+}

--- a/stack.go
+++ b/stack.go
@@ -36,15 +36,16 @@ func NewStack(programCounter uintptr) Stack {
 }
 
 // callers captures the current stack trace.
-// It skips the first 3 frames to exclude internal function calls.
-func callers() []uintptr {
+// It skips the first 3 frames plus additional frames to exclude internal function calls.
+// The skip parameter allows callers to skip additional frames as needed.
+func callers(skip int) []uintptr {
 	const (
-		callersDepth = 32
-		skipDepth    = 3
+		callersDepth     = 32
+		defaultSkipDepth = 3
 	)
 
 	var pcs [callersDepth]uintptr
-	length := runtime.Callers(skipDepth, pcs[:])
+	length := runtime.Callers(defaultSkipDepth+skip, pcs[:])
 
 	return pcs[:length]
 }


### PR DESCRIPTION
- Add NewWithCallers() for creating errors with custom callers
- Add RecoverError() helper for panic recovery scenarios
- Add ProgramCounters() method for testing stack traces
- Update documentation with panic/recover examples
- Improve test consistency using require.ErrorAs